### PR TITLE
[INFO Only] +62 MB from CoreRT

### DIFF
--- a/src/anisiblefs/Program.fs
+++ b/src/anisiblefs/Program.fs
@@ -49,6 +49,10 @@ module Result =
 
 [<EntryPoint>]
 let main argv =
+
+    // +11 MB
+    let http = new System.Net.Http.HttpClient()
+
     match argv with
     | [|argsFilePath|] ->
         match File.ReadAllText argsFilePath |> Result.ofException with

--- a/src/anisiblefs/ansiblefs.fsproj
+++ b/src/anisiblefs/ansiblefs.fsproj
@@ -3,16 +3,24 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <RootAllApplicationAssemblies>false</RootAllApplicationAssemblies>
+    <!-- 13 MB -->
+    <!-- <RootAllApplicationAssemblies>false</RootAllApplicationAssemblies> -->
   </PropertyGroup>
+
+    <ItemGroup Condition="'$(CoreRT)' != 'false'">
+        <RdXmlFile Include="rd.xml" />
+        <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
+    </ItemGroup>
 
   <ItemGroup>
     <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="chiron" Version="6.3.1" />
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
+    <PackageReference Include="chiron" Version="6.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.1.1" />
+    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Include="Argu" Version="5.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/anisiblefs/rd.xml
+++ b/src/anisiblefs/rd.xml
@@ -1,0 +1,8 @@
+<Directives>
+    <Application>
+        <!-- 20 MB -->
+        <Assembly Name="FSharp.Core" Dynamic="Required All" />
+        <!-- 18 MB -->
+        <Assembly Name="Argu" Dynamic="Required All" />
+    </Application>
+</Directives>


### PR DESCRIPTION
These changes result in growing the Linux release executable from CoreRT from about 21MB to about 83 MB. CoreRT executables grow pretty quickly in size, especially with the reflection data from rd.xml.